### PR TITLE
Change Resistance rate icon and background to cyan

### DIFF
--- a/components/StatsCard.tsx
+++ b/components/StatsCard.tsx
@@ -38,9 +38,9 @@ export default function StatsCard({ stats }: StatsCardProps) {
     {
       value: stats.resistanceRate,
       label: "Resistance rate",
-      color: "text-green-600",
-      bg: "bg-green-50",
-      emoji: "💪",
+      color: "text-cyan-600",
+      bg: "bg-cyan-50",
+      emoji: "🛡️",
     },
     {
       value: stats.todayCount,


### PR DESCRIPTION
Closes #2

- Changed Resistance rate icon from 💪 to 🛡️
- Changed background to cyan (bg-cyan-50)
- Changed text color to cyan (text-cyan-600)

Generated with [Claude Code](https://claude.ai/code)