### PR TITLE
5th D, remove push/cron, floating log CTA

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import Navbar from "@/components/Navbar";
@@ -36,6 +36,7 @@ export default function DashboardPage() {
   const [cravings, setCravings] = useState<Craving[]>([]);
   const [stats, setStats] = useState<Stats | null>(null);
   const [loading, setLoading] = useState(true);
+  const formRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     if (status === "unauthenticated") router.push("/login");
@@ -79,7 +80,7 @@ export default function DashboardPage() {
         userImage={session?.user?.image}
       />
 
-      <main className="max-w-2xl mx-auto px-4 py-8 space-y-8">
+      <main className="max-w-2xl mx-auto px-4 py-8 pb-24 space-y-8">
         {/* Stats */}
         <section>
           <div className="flex items-center gap-2 mb-4">
@@ -103,7 +104,7 @@ export default function DashboardPage() {
         </section>
 
         {/* Log form */}
-        <section>
+        <section ref={formRef}>
           <CravingForm onSuccess={fetchData} />
         </section>
 
@@ -125,6 +126,17 @@ export default function DashboardPage() {
           <CravingList cravings={cravings} onDelete={handleDelete} loading={loading} />
         </section>
       </main>
+      {/* Floating log CTA */}
+      <button
+        onClick={() => formRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })}
+        aria-label="Log a craving"
+        className="fixed bottom-6 right-5 z-30 flex items-center gap-2 rounded-full bg-indigo-600 px-5 py-3.5 text-sm font-semibold text-white shadow-lg hover:bg-indigo-700 active:scale-95 transition-all"
+      >
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+        </svg>
+        Log craving
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **5th D (Distance yourself):** Adds a new final step to the craving relief modal — prompts the user to physically change their environment. Updates all "4Ds" references to "5Ds" throughout the app, tests, and cron notification copy.
- **Remove push notifications & cron job:** Vercel Hobby plan doesn't support sub-daily cron schedules (`0 * * * *`). Removes the hourly cron, web-push API routes, service worker, `PushNotificationToggle`, `PushSubscription` DB model, VAPID env vars, and `web-push` / `@types/web-push` dependencies entirely.
- **Floating Log Craving CTA:** Adds a fixed pill-shaped FAB (bottom-right) that's always visible and smooth-scrolls to the log form on tap, since the form sits below the first fold.

## Test plan

- [ ] Open the 5Ds modal after logging a craving — verify all 5 steps appear with correct progress dots, D5 card shows rose color and "Distance yourself" copy, and the completion screen says "5Ds"
- [ ] Confirm no bell icon appears in the navbar
- [ ] Confirm `vercel.json` no longer has a crons entry (no Vercel deploy error)
- [ ] On mobile, verify the indigo "Log craving" FAB is visible on page load and scrolls to the form on tap
- [ ] Run `npm run db:push` to drop the `PushSubscription` table

https://claude.ai/code/session_01HByu13FBWkXq7Tq94rpqZD

---
_Generated by [Claude Code](https://claude.ai/code/session_01HByu13FBWkXq7Tq94rpqZD)_